### PR TITLE
:bug:駅名がからのときには、駅名クエリを空にする

### DIFF
--- a/components/SearchForm.vue
+++ b/components/SearchForm.vue
@@ -181,6 +181,7 @@ export default {
     async searchStation() {
       if (this.word.length <= 1) {
         this.stations = []
+        this.searchQuery.stationName = ""
       } else {
         const res = await axios.get(
           "https://api.cafepedia.jp/api/stations/search?",


### PR DESCRIPTION
- 駅名検索の文字列が1文字以下の時には、StaiontNameクエリを空にする