### PR TITLE
画像の遅延読み込みとSentryを本番のみに適用

### DIFF
--- a/components/CafeLists.vue
+++ b/components/CafeLists.vue
@@ -70,13 +70,13 @@
       :class="cafe.main_shop_eng_name"
     >
       <v-list-item class="mt-3">
-        <img
+        <v-img
           :src="
             `https://cafepedia-images.s3-ap-northeast-1.amazonaws.com${cafe.image}`
           "
+          lazy-src="https://picsum.photos/10/6"
           :alt="cafe.main_shop_eng_name"
-          width="48"
-          tile
+          max-width="42"
           class="mr-1"
         />
         <v-list-item-content>

--- a/components/ShowCafe.vue
+++ b/components/ShowCafe.vue
@@ -22,12 +22,14 @@
             }}</span>
           </v-col>
           <v-col cols="auto pa-0">
-            <img
+            <v-img
               :src="
                 `https://cafepedia-images.s3-ap-northeast-1.amazonaws.com${cafe.image}`
               "
-              width="90"
-              height="90"
+              lazy-src="https://picsum.photos/10/6"
+              aspect-ratio
+              max-width="86"
+              max-height="86"
             />
           </v-col>
         </v-row>
@@ -73,7 +75,7 @@
               </v-icon>
             </td>
             <td class="pl-0 body-2 white-space-pre-inline">
-              {{ cafe.business_hour }}
+              <span>{{ cafe.business_hour }}</span>
             </td>
           </tr>
           <tr v-if="cafe.other_address">
@@ -83,7 +85,9 @@
               </v-icon>
             </td>
             <td class="pl-0 body-2">
-              {{ cafe.prefecture }}{{ cafe.city }}{{ cafe.other_address }}
+              <span>
+                {{ cafe.prefecture }}{{ cafe.city }}{{ cafe.other_address }}
+              </span>
             </td>
           </tr>
           <tr v-if="cafe.access">
@@ -113,7 +117,7 @@
               </v-icon>
             </td>
             <td class="pl-0 body-2">
-              {{ cafe.chair }}
+              <span>{{ cafe.chair }}</span>
             </td>
           </tr>
           <tr v-if="cafe.tel">
@@ -123,7 +127,7 @@
               </v-icon>
             </td>
             <td class="pl-0 body-2">
-              {{ cafe.tel }}
+              <span>{{ cafe.tel }}</span>
             </td>
           </tr>
         </tbody>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -144,6 +144,7 @@ module.exports = {
   },
   sentry: {
     dsn: 'https://eb1901656a8b4fcab01d35aea67ef851@sentry.io/1831661',
+    disabled: process.env.NODE_ENV != 'production',
     config: {
       environments: ['production']
     }


### PR DESCRIPTION
- 画像の遅延読み込み(v-imgで:srcのように変数にするとConsoleErrorを吐く=https://github.com/vuetifyjs/vuetify-loader/issues/12)
- Sentryを本番のみに適用